### PR TITLE
feat: add QueueEvents, queue/worker getters, and missing options [python]

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,11 +76,11 @@
         {
           "releaseRules": [
             {
-              "message": "**/*\\[python\\]*",
+              "header": "**/*\\[python\\]*",
               "release": false
             },
             {
-              "message": "**/*\\[elixir\\]*",
+              "header": "**/*\\[elixir\\]*",
               "release": false
             }
           ]


### PR DESCRIPTION
- QueueEvents: cross-process stream event listener (QueueEvents, QueueEvent,

QueueEventEntry, QueueEventsOptions) with all Node event variants

- Queue.get_workers / get_workers_count via CLIENT SETNAME + CLIENT LIST

- Queue.get_meta / get_version / is_maxed (typed QueueMeta)

- Queue.export_prometheus_metrics with optional global labels

- Worker options: max_started_attempts, skip_stalled_check, skip_lock_renewal

- Job options: size_limit (client-side validation) and KeepJobs.limit

- Deprecated debounce aliases: get_debounce_job_id, remove_debounce_key

- Convenience methods: Queue.update_job_progress, Job.move_to_wait,

Queue.record_job_counts_metric (JobCountRecorder hook)